### PR TITLE
fix: Issue of invalid JWT token and exception throws too many retries, access denied, 401 Unauthorized error

### DIFF
--- a/terrakube-client/src/main/java/io/terrakube/client/dex/DexCredentialAuthentication.java
+++ b/terrakube-client/src/main/java/io/terrakube/client/dex/DexCredentialAuthentication.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.NonNull;
@@ -60,6 +61,7 @@ public class DexCredentialAuthentication implements Authenticator, Interceptor {
             SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(this.secretKey));
 
             newToken = Jwts.builder()
+                    .setHeaderParam("typ", "JWT")
                     .issuer(DexCredentialAuthentication.ISSUER)
                     .subject(DexCredentialAuthentication.SUBJECT)
                     .audience().add(DexCredentialAuthentication.ISSUER)
@@ -69,7 +71,7 @@ public class DexCredentialAuthentication implements Authenticator, Interceptor {
                     .claim("name", DexCredentialAuthentication.NAME)
                     .issuedAt(Date.from(Instant.now()))
                     .expiration(Date.from(Instant.now().plus(30, ChronoUnit.DAYS)))
-                    .signWith(key)
+                    .signWith(key, SignatureAlgorithm.HS256)
                     .compact();
 
         } else {


### PR DESCRIPTION
When an agent tries to communicate API backend using an internal issuer, it fails and throws an exception.

Root cause: it uses a default algorithm which is different from the API expects. e.g. HS256 vs HS512

![image1](https://github.com/user-attachments/assets/ebd8bc4e-c9c4-4b0c-9404-abb5a8b14dc4)
![image2](https://github.com/user-attachments/assets/23289811-64ec-4ba9-87c5-b6bb9f3a6f16)

